### PR TITLE
feat(templates): add AI/LLM model training data rights request template

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -121,3 +121,8 @@ If applying for API credits (e.g., Codex Open Source Fund), the highest-value us
 - build tooling improvements and automation
 - template validation/linting for safe defaults
 
+
+### Milestone 2 – Template engine discipline (in progress)
+- [x] DSAR/privacy flows
+- [x] EU261 airline compensation
+- [ ] AI / LLM Model Training Data Rights Request (new in this PR)

--- a/templates/ai-model-training-data-rights.md
+++ b/templates/ai-model-training-data-rights.md
@@ -22,7 +22,7 @@ Pursuant to applicable data subject rights, I request:
 
 5. A timeline for each step above (maximum 30 calendar days).
 
-This request is accompanied by the associated evidence packet (ID: [YOUR-PACKET-ID-HERE]) containing timeline and inventory.
+This request is accompanied by the associated evidence packet (ID referenced above) containing timeline and inventory.
 
 Please reply to this email/thread and reference the Packet ID above.
 

--- a/templates/ai-model-training-data-rights.md
+++ b/templates/ai-model-training-data-rights.md
@@ -1,6 +1,6 @@
 # AI / LLM Model Training Data Rights Request
 
-**Packet ID:** [YOUR-PACKET-ID-HERE]  
+**Packet ID:** [Packet ID]  
 **Prepared:** [YYYY-MM-DDThh:mm:ssZ UTC]  
 **Recipient:** Privacy Officer / Data Protection Officer, [Company Name]  
 **Your Reference:** [Account ID / Email (redacted) / other stable identifier]

--- a/templates/ai-model-training-data-rights.md
+++ b/templates/ai-model-training-data-rights.md
@@ -1,0 +1,36 @@
+# AI / LLM Model Training Data Rights Request
+
+**Packet ID:** [YOUR-PACKET-ID-HERE]  
+**Prepared:** [YYYY-MM-DDThh:mm:ssZ UTC]  
+**Recipient:** Privacy Officer / Data Protection Officer, [Company Name]  
+**Your Reference:** [Account ID / Email (redacted) / other stable identifier]
+
+## Formal Request (facts only)
+
+Pursuant to applicable data subject rights, I request:
+
+1. Confirmation whether any of my Personal Data has been collected or used as input for training, fine-tuning, or evaluation of any AI/LLM models operated by you.
+
+2. If yes, provide (to the extent technically available):
+   - Which specific data points or categories were used.
+   - Approximate date range of ingestion.
+   - Which model versions or releases were affected.
+
+3. Immediate cessation of any further processing of my Personal Data for training or model improvement purposes.
+
+4. Permanent deletion of my Personal Data from all training, validation, and inference datasets (including any derived embeddings or weights where technically feasible), with written confirmation of completion.
+
+5. A timeline for each step above (maximum 30 calendar days).
+
+This request is accompanied by the associated evidence packet (ID: [YOUR-PACKET-ID-HERE]) containing timeline and inventory.
+
+Please reply to this email/thread and reference the Packet ID above.
+
+Sincerely,  
+[Your Name / Pseudonym as used in the packet]
+
+## Usage notes (remove before sending)
+- Fill placeholders from your CASE.md and EVIDENCE-INVENTORY.md.
+- Attach redacted packet or refer by ID only.
+- Send via official support channel + dpo@company.com if known.
+- Keep tone procedural and restrained at all times.


### PR DESCRIPTION
- New minimalist template for opt-out + deletion from training datasets
- Covers confirmation, inventory, cessation, and erasure asks
- Fully procedural, facts-only, packet-referenced style
- Updates ROADMAP.md under Milestone 2

Aligns with core doctrine: verifiable requests to opaque systems, zero dependencies, redaction-first.

Closes #1