### PR TITLE
feat(templates): add escalation-ladder.md – full procedural chain

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -63,7 +63,7 @@ Deliverables
   - account deletion request
   - rectification request
   - airline escalation cover note (procedural, non-defamatory)
-- [ ] Escalation Ladder template (general procedural chain for any bureaucracy)
+- Escalation Ladder template (general procedural chain for any bureaucracy)
 
 Acceptance criteria
 - Templates have consistent headers, placeholders, and disclaimers where needed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -63,6 +63,7 @@ Deliverables
   - account deletion request
   - rectification request
   - airline escalation cover note (procedural, non-defamatory)
+- [ ] Escalation Ladder template (general procedural chain for any bureaucracy)
 
 Acceptance criteria
 - Templates have consistent headers, placeholders, and disclaimers where needed

--- a/src/pages/templates.md
+++ b/src/pages/templates.md
@@ -23,3 +23,5 @@ MVP set:
 - [Rectification request](../templates/privacy/rectification-request.md)
 - [EU261 compensation request](../templates/airline/eu261-compensation-request.md)
 - [Ticketing mismatch / denied boarding](../templates/airline/ticketing-mismatch-denied-boarding.md)
+
+- [Escalation Ladder (procedural chain for any bureaucracy)](../templates/escalation-ladder.md)

--- a/templates/escalation-ladder.md
+++ b/templates/escalation-ladder.md
@@ -1,0 +1,30 @@
+# Escalation Ladder (Procedural Chain)
+
+**Packet ID:** [YOUR-PACKET-ID-HERE]  
+**Prepared:** [YYYY-MM-DDThh:mm:ssZ UTC]  
+**Recipient (Step N):** [Name / Department / Regulator]  
+**Your Reference:** [Original Ticket / Packet ID]
+
+## Current Step in Ladder
+- Step 1: Initial request sent [DATE UTC] → [Ticket ID]  
+- Step 2: First follow-up [DATE UTC] → [Ticket ID]  
+- Step 3: Supervisor escalation [DATE UTC] → [Ticket ID]  
+- Step 4: Regulator / DPA / Ombudsman [DATE UTC] → [Ticket ID]
+
+## Formal Request at This Step (facts only)
+
+I reference the attached/prior evidence packet (ID: [YOUR-PACKET-ID-HERE]).
+
+Please:
+1. Confirm receipt of the original packet and all prior correspondence.
+2. Provide a written update on the status of my request dated [ORIGINAL DATE UTC].
+3. Supply a firm resolution date (maximum 30 calendar days from today).
+4. If unable to resolve internally, escalate immediately to the next competent authority and notify me of the new reference.
+
+Reply to this thread referencing Packet ID and current Step number above.
+
+## Ladder Usage Notes (remove before sending)
+- Copy-paste relevant block for each new email.
+- Attach only the latest redacted packet (use simple-redact.sh).
+- Maintain strict chronological order and UTC timestamps.
+- Tone remains neutral and procedural at every step.

--- a/templates/escalation-ladder.md
+++ b/templates/escalation-ladder.md
@@ -2,6 +2,7 @@
 
 **Packet ID:** [YOUR-PACKET-ID-HERE]  
 **Prepared:** [YYYY-MM-DDThh:mm:ssZ UTC]  
+**Subject:** Escalation Step N - Packet [YOUR-PACKET-ID-HERE]  
 **Recipient (Step N):** [Name / Department / Regulator]  
 **Your Reference:** [Original Ticket / Packet ID]
 
@@ -18,13 +19,13 @@ I reference the attached/prior evidence packet (ID: [YOUR-PACKET-ID-HERE]).
 Please:
 1. Confirm receipt of the original packet and all prior correspondence.
 2. Provide a written update on the status of my request dated [ORIGINAL DATE UTC].
-3. Supply a firm resolution date (maximum 30 calendar days from today).
+3. Supply a firm resolution date (within the applicable legal response period).
 4. If unable to resolve internally, escalate immediately to the next competent authority and notify me of the new reference.
 
 Reply to this thread referencing Packet ID and current Step number above.
 
 ## Ladder Usage Notes (remove before sending)
 - Copy-paste relevant block for each new email.
-- Attach only the latest redacted packet (use simple-redact.sh).
+- Attach only the latest redacted packet (use `tools/scripts/simple-redact.sh`).
 - Maintain strict chronological order and UTC timestamps.
 - Tone remains neutral and procedural at every step.


### PR DESCRIPTION
- Single reusable template covering support → supervisor → regulator/DPA/ombudsman
- Strict facts-only, UTC timeline, packet-referenced style
- Complements simple-redact.sh and existing DSAR/AI templates
- Directly advances Milestone 2 (Template engine discipline)

Closes #5